### PR TITLE
[1.1.1] fix getters file unnecessary extension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Release] 1.1.1
+### Fixed
+- Remove unnecessary store file import extension to avoid TSLint warnings
+
 ## [Release] 1.1.0
 ### Added
 - Specify destination folder is now possible with `--dest <destination path>` option

--- a/lib/blueprints/component/temp.getters.extension
+++ b/lib/blueprints/component/temp.getters.extension
@@ -1,4 +1,4 @@
-import { {{name | PascalCase}}State } from  './{{ name }}.store.{{ filesType.script }}';
+import { {{name | PascalCase}}State } from  './{{ name }}.store';
 
 export const {{name | camelCase}}Getters = {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-generate-component-x",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Vue js component generator. Supports creating files for vuex store, and actions",
   "main": "lib/vgc.js",
   "homepage": "https://github.com/justgeek/vue-generate-component",


### PR DESCRIPTION
## [Release] 1.1.1
### Fixed
- Remove unnecessary store file import extension to avoid TSLint warnings