### PR TITLE
[1.1.3] Remove scoped style

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Release] 1.1.2
+## [Hotfix] 1.1.3
+### Fixed
+- Remove scoped styles from index.vue (use css specifity)
+
+## [Hotfix] 1.1.2
 ### Fixed
 - Fix test file pointing to wrong page file
 - Remove unnecessary store file import extension to avoid TSLint warnings
 
-## [Release] 1.1.1
+## [Hotfix] 1.1.1
 ### Fixed
 - Remove unnecessary store file import extension to avoid TSLint warnings
 

--- a/lib/blueprints/component/index.vue
+++ b/lib/blueprints/component/index.vue
@@ -1,3 +1,3 @@
 <template src="./{{name}}{% if postfix %}.{{postfix}}{% endif %}.{{ filesType.html }}"></template>
 <script src="./{{name}}{% if postfix %}.{{postfix}}{% endif %}.{{ filesType.script }}"{% if filesType.script !="js" %} lang="{{ filesType.script }}"{% endif %}></script>
-<style src="./{{name}}{% if postfix %}.{{postfix}}{% endif %}.{{ filesType.style }}" scoped lang="{{ filesType.style }}"></style>
+<style src="./{{name}}{% if postfix %}.{{postfix}}{% endif %}.{{ filesType.style }}" lang="{{ filesType.style }}"></style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-generate-component-x",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Vue js component generator. Supports creating files for vuex store, and actions",
   "main": "lib/vgc.js",
   "homepage": "https://github.com/justgeek/vue-generate-component",


### PR DESCRIPTION
## [Hotfix] 1.1.3
### Fixed
- Remove scoped styles from index.vue (use css specifity)